### PR TITLE
22 - Run the app on iOS simulator locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
   * [Mac version](#mac-version)
   * [Windows version](#windows-version)
   * [Running the app locally](#running-locally)
+    * [Run the iOS Simulator](#run-the-ios-simulator)
+* [Testing](#testing)
 
 ## Team composition
 
@@ -300,11 +302,24 @@ Note: an Emulator will have to be set up in Android Studio first - this is for a
   * `%ANDROID_HOME%/emulator/emulator -avd Pixel_3_API_28 -netdelay none -netspeed full` - will run the AVD `Pixel_3_API_28`
 
 ### Build the apk for Android
-=======
+
 * `emulator -list-avds` - will show all installed AVDs
 * `emulator -avd Pixel_3_API_28 -netdelay none -netspeed full` - will run the AVD `Pixel_3_API_28`
 
 In directory `android` run `./gradlew assembleRelease -x bundleReleaseJsAndAssets`. The apk file should reside in `947g5/android/app/build/outputs/apk/release`.
+
+### Run the iOS simulator
+
+Required:
+* XCode v10+ with Command line tools
+* Cocoapods (in project root run `gem install cocoapods`)
+* iOS Simulator v12.4
+
+How to start the app for iOS:
+
+* in project root `gem install cocoapods`
+* in ios directory of the app `pod install`
+* in project root `react-native run-ios`
 
 ## Testing
 


### PR DESCRIPTION
In order to run it locally on iOS, we need:

Required:
* XCode v10+ with Command line tools
* Cocoapods (in project root run `gem install cocoapods`)
* iOS Simulator v12.4

How to start the app for iOS:

* in project root `gem install cocoapods`
* in ios directory of the app `pod install`
* in project root `react-native run-ios`