### PR TITLE
30: Fixed silent failing Travis CI condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,8 +95,8 @@ jobs:
     - cd ios
     - bundle install
     - bundle exec fastlane ios tests
-  - stage: Beta release
-    if: (branch = master) AND (type = merge)
+  - stage: Version patch
+    if: (branch = master) AND (type = push)
     name: Version patch
     language: node_js
     os: linux
@@ -110,7 +110,7 @@ jobs:
     - npm test
     - "./infra/ci/beta_patch"
   - stage: Beta release
-    if: (branch = master) AND (type = merge)
+    if: (branch = master) AND (type = push)
     name: Android Beta release
     language: android
     jdk: oraclejdk8
@@ -162,7 +162,7 @@ jobs:
     - bundle exec fastlane install_plugins
     - bundle exec fastlane android beta
   - stage: Master release
-    if: (branch = master) AND (type != merge) AND (env(RELEASE_MASTER) = true)
+    if: (branch = master) AND (type != push) AND (env(RELEASE_MASTER) = true)
     name: Android release
     language: android
     env:


### PR DESCRIPTION
- Travis CI doesn't have an event type `merge`, so we will use `push`.
It was failing silently which is not nice.